### PR TITLE
Balances `fountain-outline-to-indirect-buffer'.

### DIFF
--- a/fountain-mode.el
+++ b/fountain-mode.el
@@ -3842,7 +3842,7 @@ buffer windows are opened."
         (pop-to-buffer target-buffer)
       (clone-indirect-buffer target-buffer t)
       (outline-show-all))
-    (narrow-to-region beg end))))
+    (narrow-to-region beg end)))
 
 
 ;;; Navigation


### PR DESCRIPTION
`fountain-outline-to-indirect-buffer` has an extra parentheses at the end of its definition.

This removes it.