### PR TITLE
added a "production" wrap option for export.

### DIFF
--- a/fountain-mode.el
+++ b/fountain-mode.el
@@ -2877,6 +2877,8 @@ The car sets `left-margin' and cdr `fill-column'."
 --setting print_profile=a4")
     ("wrap-usletterpdf-cprime" . "wrap \
 pdf %b --use-courier-prime --out %B.pdf")
+    ("wrap-usletterpdf-cprime-production" . "wrap \
+pdf -p %b --use-courier-prime --out %B.pdf")
     ("textplay-fdx" . "textplay --fdx < %b > %B.fdx"))
   "Shell command profiles for exporting Fountain files.
 


### PR DESCRIPTION
This simply adds the "-p" flag to the "wrap pdf" export function as a new fountain-mode export option.

I write for animation, and need scene numbers in scripts all of the time. Having this option in fountain-mode will keep me from having to jump to the command line.

I've already been using this on my own, and thought others could benefit.