### PR TITLE
Add emphasis markup functions

### DIFF
--- a/fountain-mode.el
+++ b/fountain-mode.el
@@ -2156,17 +2156,18 @@ If no selected text, insert \"_\" before and after point."
   "Mark up the text with MARKUP, at the front and back of the region.
 
 If there is no active region, insert MARKUP before and after point."
-  (save-excursion
-    (insert markup)
-    (when (use-region-p)
-      (goto-char (mark)))
-    (insert markup))
-  (when (or (< (point) (mark))
-            (not (use-region-p)))
-    ;; When point is before mark, that means the user highlighted backwards, and we're before the markup first in the buffer.
-    ;; When (not (use-region-p)), we've inserted the markup twice, and we're before the first markup.
-    ;; Either way, move forwards, so we're /after/ the first markup inserted.
-    (forward-char (length markup))))
+  (let ((original-point (point)))
+    (if (use-region-p)
+        (let ((beginning (region-beginning))
+              (end (region-end)))
+          (goto-char end)
+          (insert markup)
+
+          (goto-char beginning)
+          (insert markup))
+      (insert markup markup))
+    ;;since we always insert markup once before point:
+    (goto-char (+ original-point (length markup)))))
 
 
 ;;; Scene Numbers

--- a/fountain-mode.el
+++ b/fountain-mode.el
@@ -2145,6 +2145,13 @@ If no selected text, insert \"*\" before and after point."
   (interactive)
   (fountain--markup-dwim "*"))
 
+(defun fountain-underline-dwim ()
+  "Make the selected text underscored.
+
+If no selected text, insert \"_\" before and after point."
+  (interactive)
+  (fountain--markup-dwim "_"))
+
 (defun fountain--markup-dwim (markup)
   "Mark up the text with MARKUP, at the front and back of the region.
 
@@ -3246,6 +3253,7 @@ redisplay in margin. Otherwise, remove display text properties."
     (define-key map (kbd "TAB") #'fountain-dwim)
     (define-key map (kbd "C-c C-f b") #'fountain-bold-dwim)
     (define-key map (kbd "C-c C-f i") #'fountain-italicize-dwim)
+    (define-key map (kbd "C-c C-f u") #'fountain-underline-dwim)
     (define-key map (kbd "C-c RET") #'fountain-upcase-line-and-newline)
     (define-key map (kbd "<S-return>") #'fountain-upcase-line-and-newline)
     (define-key map (kbd "C-c C-c") #'fountain-upcase-line)

--- a/fountain-mode.el
+++ b/fountain-mode.el
@@ -2130,6 +2130,37 @@ to remove previous string first."
             (progress-reporter-update job)))
         (progress-reporter-done job)))))
 
+;; TODO: make this apply AND remove markup.
+(defun fountain-bold-dwim ()
+  "Make the selected text bold.
+
+If no selected text, insert \"**\" before and after point."
+  (interactive)
+  (fountain--markup-dwim "**"))
+
+(defun fountain-italicize-dwim ()
+  "Make the selected text italic.
+
+If no selected text, insert \"*\" before and after point."
+  (interactive)
+  (fountain--markup-dwim "*"))
+
+(defun fountain--markup-dwim (markup)
+  "Mark up the text with MARKUP, at the front and back of the region.
+
+If there is no active region, insert MARKUP before and after point."
+  (save-excursion
+    (insert markup)
+    (when (use-region-p)
+      (goto-char (mark)))
+    (insert markup))
+  (when (or (< (point) (mark))
+            (not (use-region-p)))
+    ;; When point is before mark, that means the user highlighted backwards, and we're before the markup first in the buffer.
+    ;; When (not (use-region-p)), we've inserted the markup twice, and we're before the first markup.
+    ;; Either way, move forwards, so we're /after/ the first markup inserted.
+    (forward-char (length markup))))
+
 
 ;;; Scene Numbers
 
@@ -3213,6 +3244,8 @@ redisplay in margin. Otherwise, remove display text properties."
   (let ((map (make-sparse-keymap)))
     ;; Editing commands:
     (define-key map (kbd "TAB") #'fountain-dwim)
+    (define-key map (kbd "C-c b") #'fountain-bold-dwim)
+    (define-key map (kbd "C-c i") #'fountain-italicize-dwim)
     (define-key map (kbd "C-c RET") #'fountain-upcase-line-and-newline)
     (define-key map (kbd "<S-return>") #'fountain-upcase-line-and-newline)
     (define-key map (kbd "C-c C-c") #'fountain-upcase-line)

--- a/fountain-mode.el
+++ b/fountain-mode.el
@@ -3244,8 +3244,8 @@ redisplay in margin. Otherwise, remove display text properties."
   (let ((map (make-sparse-keymap)))
     ;; Editing commands:
     (define-key map (kbd "TAB") #'fountain-dwim)
-    (define-key map (kbd "C-c b") #'fountain-bold-dwim)
-    (define-key map (kbd "C-c i") #'fountain-italicize-dwim)
+    (define-key map (kbd "C-c C-f b") #'fountain-bold-dwim)
+    (define-key map (kbd "C-c C-f i") #'fountain-italicize-dwim)
     (define-key map (kbd "C-c RET") #'fountain-upcase-line-and-newline)
     (define-key map (kbd "<S-return>") #'fountain-upcase-line-and-newline)
     (define-key map (kbd "C-c C-c") #'fountain-upcase-line)


### PR DESCRIPTION
These are simple functions to make it easier to make text bold and italic. I submitted this PR rather than open an issue because the functions were easy enough to write.

I bound them to `C-c b` and `C-c i`, because that made the most sense to me; `C-c C-i` is already taken.

Eventually, these should remove bold and italic, if called on text that already has these properties. But they're still quite useful now.