### PR TITLE
exec-path is a variable, not a function

### DIFF
--- a/fountain-mode.el
+++ b/fountain-mode.el
@@ -3007,7 +3007,7 @@ The file is then passed to `dired-guess-default'."
     (unless (listp command-list) (setq command-list (list command-list)))
     (setq command
           (seq-find (lambda (str)
-                      (locate-file str (exec-path) nil 'file-executable-p))
+                      (locate-file str exec-path nil 'file-executable-p))
                     command-list))
     (unless (stringp command)
       (user-error "%S not configured correctly" 'dired-guess-shell-alist-user))


### PR DESCRIPTION
fixes an error when trying to view last exported file:
"locate-file: Symbol’s function definition is void: exec-path"