### PR TITLE
fix endless loop in fountain-count-pages w/o newline at end of file (issue #124)

### DIFF
--- a/fountain-mode.el
+++ b/fountain-mode.el
@@ -2584,7 +2584,7 @@ Skip over comments."
          (cdr (symbol-value
                (intern-soft (format "fountain-fill-%s" element))))))
     (let ((i 0))
-      (while (and (< i fill-width) (not (eolp)) (not (eobp)))
+      (while (and (< i fill-width) (not (eolp)))
         (cond ((= (syntax-class (syntax-after (point))) 0)
                (forward-char 1) (cl-incf i))
               ((forward-comment 1))

--- a/fountain-mode.el
+++ b/fountain-mode.el
@@ -2726,9 +2726,9 @@ as a string to force the page number."
         (while (< (point) (point-max))
           (fountain-forward-page)
           (cl-incf total)
-          (when (and (not found) (<= x (point)))
+          (when (and (not found) (< x (point)))
             (setq current total found t)))
-        (cons current total)))))
+        (cons (if found current total)  total)))))
 
 (defun fountain-count-pages ()
   "Message the current page of total pages in current buffer.

--- a/fountain-mode.el
+++ b/fountain-mode.el
@@ -2505,6 +2505,8 @@ Comments are assumed to be deleted."
   (when (looking-at "[\n\s\t]*\n") (goto-char (match-end 0)))
   (let ((element (fountain-get-element)))
     (cond
+     ;; End of buffer
+     ((eobp) nil)
      ;; If element is not included in export, we can safely break
      ;; before.
      ((not (memq element fountain-printed-elements))
@@ -2582,7 +2584,7 @@ Skip over comments."
          (cdr (symbol-value
                (intern-soft (format "fountain-fill-%s" element))))))
     (let ((i 0))
-      (while (and (< i fill-width) (not (eolp)))
+      (while (and (< i fill-width) (not (eolp)) (not (eobp)))
         (cond ((= (syntax-class (syntax-after (point))) 0)
                (forward-char 1) (cl-incf i))
               ((forward-comment 1))
@@ -2590,7 +2592,7 @@ Skip over comments."
                (forward-char 1) (cl-incf i)))))
     (skip-chars-forward "\s\t")
     (when (eolp) (forward-line))
-    (unless (bolp) (fill-move-to-break-point (line-beginning-position)))))
+    (unless (or (bolp) (eobp)) (fill-move-to-break-point (line-beginning-position)))))
 
 (defun fountain-forward-page ()
   "Move point forward by an approximately page.


### PR DESCRIPTION
- modified `fountain-goto-page-break-point` to handle end of buffer like whitespace
- fixed behavior of `fountain-move-to-fill-width` at end of buffer